### PR TITLE
move istanbul to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,9 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {
-    "istanbul": "^0.3.2"
-  },
   "devDependencies": {
-    "mocha": "^1.21.4"
+    "mocha": "^1.21.4",
+    "istanbul": "^0.3.2"
   },
   "scripts": {
     "coverage": "istanbul cover mocha -- test/*.js",


### PR DESCRIPTION
Due to pulling in istanbul as a standard dependency it could happen to break builds or even install unwanted packages in production environments.
