### PR TITLE
periodially yield the event loop

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -60,7 +60,7 @@ function pbkdf2 (password, salt, iterations, keylen, digest, callback) {
     var destPos = (i - 1) * hLen
     var len = (i === l ? r : hLen)
     T.copy(DK, destPos, 0, len)
-    if (i <= l) {
+    if (i < l) {
       i++
       setTimeout(round)
     } else {

--- a/browser.js
+++ b/browser.js
@@ -14,14 +14,62 @@ function pbkdf2 (password, salt, iterations, keylen, digest, callback) {
     throw new Error('No callback provided to pbkdf2')
   }
 
-  setTimeout(function () {
-    var result = pbkdf2Sync(password, salt, iterations, keylen, digest)
+  digest = digest || 'sha1'
 
-    callback(null, result)
-  })
+  if (!Buffer.isBuffer(password)) password = new Buffer(password, 'binary')
+  if (!Buffer.isBuffer(salt)) salt = new Buffer(salt, 'binary')
+
+  var hLen
+  var l = 1
+  var DK = new Buffer(keylen)
+  var block1 = new Buffer(salt.length + 4)
+  salt.copy(block1, 0, 0, salt.length)
+
+  var r
+  var T
+  var U
+
+  var i = 1
+
+  setTimeout(round)
+  function round () {
+    block1.writeUInt32BE(i, salt.length)
+    U = createHmac(digest, password).update(block1).digest()
+
+    if (!hLen) {
+      hLen = U.length
+      T = new Buffer(hLen)
+      l = Math.ceil(keylen / hLen)
+      r = keylen - (l - 1) * hLen
+    }
+
+    U.copy(T, 0, 0, hLen)
+    setTimeout(loop, 0, 1)
+  }
+  function loop (j) {
+    while (j < iterations) {
+      U = createHmac(digest, password).update(U).digest()
+
+      for (var k = 0; k < hLen; k++) {
+        T[k] ^= U[k]
+      }
+      j++
+
+      if (!(j % 1000)) return setTimeout(loop, 0, j)
+    }
+    var destPos = (i - 1) * hLen
+    var len = (i === l ? r : hLen)
+    T.copy(DK, destPos, 0, len)
+    if (i <= l) {
+      i++
+      setTimeout(round)
+    } else {
+      callback(null, DK)
+    }
+  }
 }
 
-function checkParameters(iterations, keylen) {
+function checkParameters (iterations, keylen) {
   if (typeof iterations !== 'number') {
     throw new TypeError('Iterations not a number')
   }


### PR DESCRIPTION
what this does is adds a setTimeout once every outer loop (the one based on on the difference in size between the hash and the output) and then once every 1000 iterations of the inner loop.

The performance of this may be very slightly lower due to there being more functions but the latency of this will be what mainly increases (aka simple timing tests will show it taking more time but that is due to the setTimeout added pause, if you were to run a bunch simultaneously it likely wouldn't take much longer then before)