### PR TITLE
protect 0.10 users by throwing

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 var crypto = require('crypto')
+if (crypto.pbkdf2Sync.toString().indexOf('keylen, digest') === -1) {
+  throw new Error('Unsupported crypto version')
+}
 
 exports.pbkdf2Sync = crypto.pbkdf2Sync
 exports.pbkdf2 = crypto.pbkdf2


### PR DESCRIPTION
Otherwise,  this module is secretly allowing `0.10` versions to secretly work without any indication of error.

https://github.com/crypto-browserify/pbkdf2/pull/36 should not have been merged without a major version bump.

The right thing to do would have been to go to `4.0.0` for node 6 support and its `binary`/`utf-8` switch up,  then bump https://github.com/crypto-browserify/crypto-browserify/blob/master/package.json#L28.