### PR TITLE
use the local implementations if crypto.bpkdf2Sync

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var crypto = require('crypto')
 /* istanbul ignore next */
-if (crypto && crypto.pbkdf2Sync && crypto.pbkdf2Sync.toString().indexOf('keylen, digest') === -1) {
+if (crypto && (!crypto.pbkdf2Sync || crypto.pbkdf2Sync.toString().indexOf('keylen, digest') === -1)) {
   exports.pbkdf2 = require('./lib/async')
   exports.pbkdf2Sync = require('./lib/sync')
 } else {


### PR DESCRIPTION
When using crypto-browserify implementation of crypto, it appears to depend on this package to initialize it's pbkdf2* functions.  This loop, however, ends with null implementations for these functions.  My fix is to change the selection logic to select the internal implementations if either the pbkdf2Sync doesn't exist at all, or if it does, it doesn't contain the marker-string.

What do you think?