### PR TITLE
Throw if password / salt is not a buffer or string

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -65,10 +65,11 @@ function resolvePromise (promise, callback) {
   })
 }
 module.exports = function (password, salt, iterations, keylen, digest, callback) {
+  checkParameters(password, salt, iterations, keylen)
+
   if (!Buffer.isBuffer(password)) password = Buffer.from(password, defaultEncoding)
   if (!Buffer.isBuffer(salt)) salt = Buffer.from(salt, defaultEncoding)
 
-  checkParameters(iterations, keylen)
   if (typeof digest === 'function') {
     callback = digest
     digest = undefined

--- a/lib/precondition.js
+++ b/lib/precondition.js
@@ -1,5 +1,15 @@
 var MAX_ALLOC = Math.pow(2, 30) - 1 // default in iojs
-module.exports = function (iterations, keylen) {
+
+function checkBuffer (buf, name) {
+  if (typeof buf !== 'string' && !Buffer.isBuffer(buf)) {
+    throw new TypeError(name + ' must be a buffer or string')
+  }
+}
+
+module.exports = function (password, salt, iterations, keylen) {
+  checkBuffer(password, 'Password')
+  checkBuffer(salt, 'Salt')
+
   if (typeof iterations !== 'number') {
     throw new TypeError('Iterations not a number')
   }

--- a/lib/sync-browser.js
+++ b/lib/sync-browser.js
@@ -63,10 +63,10 @@ function getDigest (alg) {
 }
 
 function pbkdf2 (password, salt, iterations, keylen, digest) {
+  checkParameters(password, salt, iterations, keylen)
+
   if (!Buffer.isBuffer(password)) password = Buffer.from(password, defaultEncoding)
   if (!Buffer.isBuffer(salt)) salt = Buffer.from(salt, defaultEncoding)
-
-  checkParameters(iterations, keylen)
 
   digest = digest || 'sha1'
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -15,10 +15,11 @@ var defaultEncoding = require('../lib/default-encoding')
 var Buffer = require('safe-buffer').Buffer
 
 function pbkdf2 (password, salt, iterations, keylen, digest) {
+  checkParameters(password, salt, iterations, keylen)
+
   if (!Buffer.isBuffer(password)) password = Buffer.from(password, defaultEncoding)
   if (!Buffer.isBuffer(salt)) salt = Buffer.from(salt, defaultEncoding)
 
-  checkParameters(iterations, keylen)
   digest = digest || 'sha1'
 
   var DK = Buffer.allocUnsafe(keylen)

--- a/test/index.js
+++ b/test/index.js
@@ -92,6 +92,30 @@ function runTests (name, compat) {
     }, /No callback provided to pbkdf2/)
   })
 
+  tape(name + ' should throw if the password is not a buffer or string', function (t) {
+    t.plan(2)
+
+    t.throws(function () {
+      compat.pbkdf2(['a'], 'salt', 1, 32, 'sha1')
+    }, /Password must be a buffer or string/)
+
+    t.throws(function () {
+      compat.pbkdf2Sync(['a'], 'salt', 1, 32, 'sha1')
+    }, /Password must be a buffer or string/)
+  })
+
+  tape(name + ' should throw if the salt is not a buffer or string', function (t) {
+    t.plan(2)
+
+    t.throws(function () {
+      compat.pbkdf2('pass', ['salt'], 1, 32, 'sha1')
+    }, /Salt must be a buffer or string/)
+
+    t.throws(function () {
+      compat.pbkdf2Sync('pass', ['salt'], 1, 32, 'sha1')
+    }, /Salt must be a buffer or string/)
+  })
+
   var algos = ['sha1', 'sha224', 'sha256', 'sha384', 'sha512']
   algos.forEach(function (algorithm) {
     fixtures.valid.forEach(function (f) {


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/19699

Certain invalid inputs can result in security risks, e.g. when passing an array containing invalid values:

```js
> Buffer.from([ 'abc' ])
<Buffer 00>
> Buffer.from([ 'abcd' ])
<Buffer 00>
```

The resulting buffers have the same contents even though different "passwords" were used, thus yielding the same key when applying `pbkdf2`.

Note that this change causes `pbkdf2` to throw even for some previously allowed and seemingly valid inputs such as `[ 1, 2, 3 ]`. This is intended to match the behavior of Node.js:

```js
> crypto.pbkdf2Sync([ 1, 2, 3 ], Buffer.from([ 1, 2, 3 ]), 10, 32, 'sha256')
TypeError: Pass phrase must be a buffer
```