### PR TITLE
check if process.version is available

### DIFF
--- a/lib/default-encoding.js
+++ b/lib/default-encoding.js
@@ -2,9 +2,11 @@ var defaultEncoding
 /* istanbul ignore next */
 if (process.browser) {
   defaultEncoding = 'utf-8'
-} else {
+} else if (process.version) {
   var pVersionMajor = parseInt(process.version.split('.')[0].slice(1), 10)
 
   defaultEncoding = pVersionMajor >= 6 ? 'utf-8' : 'binary'
+} else {
+  defaultEncoding = 'utf-8'
 }
 module.exports = defaultEncoding


### PR DESCRIPTION
I use the Hapi Joi module in Nativescript for validations, because it's a cool validation module.

And Joi drags in pbkdf2, but the native app isn't running in Node so there is no process.version variable, and it causes the app to crash.

This minor code change just adds a check to see if process.version is defined and if it's not, it defaults the encoding to UTF-8, similar to the browser scenario, thus keeping Joi from crashing.

Shouldn't make any difference in a Node environment....but sure helps otherwise! ;-)

Thanks!