### PR TITLE
Build type check into toBuffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,13 @@
-var checkParameters = require('./lib/precondition')
 var native = require('crypto')
 
+var checkParameters = require('./lib/precondition')
+var defaultEncoding = require('./lib/default-encoding')
+var toBuffer = require('./lib/to-buffer')
+
 function nativePBKDF2 (password, salt, iterations, keylen, digest, callback) {
-  checkParameters(password, salt, iterations, keylen)
+  checkParameters(iterations, keylen)
+  password = toBuffer(password, defaultEncoding, 'Password')
+  salt = toBuffer(salt, defaultEncoding, 'Salt')
 
   if (typeof digest === 'function') {
     callback = digest
@@ -14,7 +19,9 @@ function nativePBKDF2 (password, salt, iterations, keylen, digest, callback) {
 }
 
 function nativePBKDF2Sync (password, salt, iterations, keylen, digest) {
-  checkParameters(password, salt, iterations, keylen)
+  checkParameters(iterations, keylen)
+  password = toBuffer(password, defaultEncoding, 'Password')
+  salt = toBuffer(salt, defaultEncoding, 'Salt')
   digest = digest || 'sha1'
   return native.pbkdf2Sync(password, salt, iterations, keylen, digest)
 }

--- a/lib/async.js
+++ b/lib/async.js
@@ -1,8 +1,9 @@
+var Buffer = require('safe-buffer').Buffer
+
 var checkParameters = require('./precondition')
 var defaultEncoding = require('./default-encoding')
 var sync = require('./sync')
 var toBuffer = require('./to-buffer')
-var Buffer = require('safe-buffer').Buffer
 
 var ZERO_BUF
 var subtle = global.crypto && global.crypto.subtle
@@ -88,10 +89,10 @@ module.exports = function (password, salt, iterations, keylen, digest, callback)
     })
   }
 
-  checkParameters(password, salt, iterations, keylen)
+  checkParameters(iterations, keylen)
+  password = toBuffer(password, defaultEncoding, 'Password')
+  salt = toBuffer(salt, defaultEncoding, 'Salt')
   if (typeof callback !== 'function') throw new Error('No callback provided to pbkdf2')
-  password = toBuffer(password, defaultEncoding)
-  salt = toBuffer(salt, defaultEncoding)
 
   resolvePromise(checkNative(algo).then(function (resp) {
     if (resp) return browserPbkdf2(password, salt, iterations, keylen, algo)

--- a/lib/precondition.js
+++ b/lib/precondition.js
@@ -1,16 +1,6 @@
 var MAX_ALLOC = Math.pow(2, 30) - 1 // default in iojs
 
-function checkType (variable, name) {
-  // checks if the variable is a string or a typed array
-  if (typeof variable !== 'string' && !ArrayBuffer.isView(variable)) {
-    throw new TypeError(name + ' must be a string or an ArrayBuffer')
-  }
-}
-
-module.exports = function (password, salt, iterations, keylen) {
-  checkType(password, 'Password')
-  checkType(salt, 'Salt')
-
+module.exports = function (iterations, keylen) {
   if (typeof iterations !== 'number') {
     throw new TypeError('Iterations not a number')
   }

--- a/lib/sync-browser.js
+++ b/lib/sync-browser.js
@@ -1,11 +1,12 @@
 var md5 = require('create-hash/md5')
 var RIPEMD160 = require('ripemd160')
 var sha = require('sha.js')
-var toBuffer = require('./to-buffer')
+var Buffer = require('safe-buffer').Buffer
 
 var checkParameters = require('./precondition')
 var defaultEncoding = require('./default-encoding')
-var Buffer = require('safe-buffer').Buffer
+var toBuffer = require('./to-buffer')
+
 var ZEROS = Buffer.alloc(128)
 var sizes = {
   md5: 16,
@@ -67,10 +68,9 @@ function getDigest (alg) {
 }
 
 function pbkdf2 (password, salt, iterations, keylen, digest) {
-  checkParameters(password, salt, iterations, keylen)
-
-  password = toBuffer(password, defaultEncoding)
-  salt = toBuffer(salt, defaultEncoding)
+  checkParameters(iterations, keylen)
+  password = toBuffer(password, defaultEncoding, 'Password')
+  salt = toBuffer(salt, defaultEncoding, 'Salt')
 
   digest = digest || 'sha1'
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -10,16 +10,16 @@ var sizes = {
 }
 
 var createHmac = require('create-hmac')
-var checkParameters = require('../lib/precondition')
-var defaultEncoding = require('../lib/default-encoding')
 var Buffer = require('safe-buffer').Buffer
+
+var checkParameters = require('./precondition')
+var defaultEncoding = require('./default-encoding')
 var toBuffer = require('./to-buffer')
 
 function pbkdf2 (password, salt, iterations, keylen, digest) {
-  checkParameters(password, salt, iterations, keylen)
-
-  password = toBuffer(password, defaultEncoding)
-  salt = toBuffer(salt, defaultEncoding)
+  checkParameters(iterations, keylen)
+  password = toBuffer(password, defaultEncoding, 'Password')
+  salt = toBuffer(salt, defaultEncoding, 'Salt')
 
   digest = digest || 'sha1'
 

--- a/lib/to-buffer.js
+++ b/lib/to-buffer.js
@@ -1,13 +1,13 @@
 var Buffer = require('safe-buffer').Buffer
 
-module.exports = (thing, encoding) => {
+module.exports = (thing, encoding, name) => {
   if (Buffer.isBuffer(thing)) {
     return thing
-  }
-  if (typeof thing === 'string') {
+  } else if (typeof thing === 'string') {
     return Buffer.from(thing, encoding)
-  }
-  if (ArrayBuffer.isView(thing)) {
+  } else if (ArrayBuffer.isView(thing)) {
     return Buffer.from(thing.buffer)
+  } else {
+    throw new TypeError(name + ' must be a string, a Buffer, a typed array or a DataView')
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -102,11 +102,11 @@ function runTests (name, compat) {
 
     t.throws(function () {
       compat.pbkdf2(['a'], 'salt', 1, 32, 'sha1', function () {})
-    }, /Password must be a string or an ArrayBuffer/)
+    }, /Password must be a string, a Buffer, a typed array or a DataView/)
 
     t.throws(function () {
       compat.pbkdf2Sync(['a'], 'salt', 1, 32, 'sha1')
-    }, /Password must be a string or an ArrayBuffer/)
+    }, /Password must be a string, a Buffer, a typed array or a DataView/)
   })
 
   tape(name + ' should throw if the salt is not a string or an ArrayBuffer', function (t) {
@@ -114,11 +114,11 @@ function runTests (name, compat) {
 
     t.throws(function () {
       compat.pbkdf2('pass', ['salt'], 1, 32, 'sha1')
-    }, /Salt must be a string or an ArrayBuffer/)
+    }, /Salt must be a string, a Buffer, a typed array or a DataView/)
 
     t.throws(function () {
       compat.pbkdf2Sync('pass', ['salt'], 1, 32, 'sha1')
-    }, /Salt must be a string or an ArrayBuffer/)
+    }, /Salt must be a string, a Buffer, a typed array or a DataView/)
   })
 
   var algos = ['sha1', 'sha224', 'sha256', 'sha384', 'sha512', 'ripemd160']


### PR DESCRIPTION
Follow up on #81

The idea is to have a normalizer (toBuffer) that only normalized the types it understands. This way we ensure type checking and the conversion is always in sync.