### PR TITLE
process.version is undefined bug fix

### DIFF
--- a/lib/default-encoding.js
+++ b/lib/default-encoding.js
@@ -3,7 +3,7 @@ var defaultEncoding
 if (global.process && global.process.browser) {
   defaultEncoding = 'utf-8'
 } else if (global.process && global.process.version) {
-  var pVersionMajor = parseInt(process.version.split('.')[0].slice(1), 10)
+  var pVersionMajor = parseInt(global.process.version.split('.')[0].slice(1), 10)
 
   defaultEncoding = pVersionMajor >= 6 ? 'utf-8' : 'binary'
 } else {


### PR DESCRIPTION
process.version is currently undefined which is breaking an app that I'm working on for myself and other windows users on my team.

![processVersion](https://user-images.githubusercontent.com/53655907/116738371-f8033080-a9b7-11eb-9b7d-2fe56a7d3a00.PNG)
![processversionundefined](https://user-images.githubusercontent.com/53655907/116738392-ff2a3e80-a9b7-11eb-9bb2-88645c2ef226.PNG)


Switching if from process.version to global.process.version fixes it.

